### PR TITLE
Support for file type in swagger

### DIFF
--- a/lib/SwaggerManager.js
+++ b/lib/SwaggerManager.js
@@ -1,6 +1,8 @@
 var _ = require('underscore'),
 	fs = require('fs');
 
+var SupportedHacks = ['file'];
+
 var SwaggerManager = function(options) {
 
 	options = options || {};
@@ -56,6 +58,14 @@ var SwaggerManager = function(options) {
 				if (type === 'payload') {
 					// keep an eye on https://github.com/wordnik/swagger-ui/issues/72
 					// looks like there might be change as far as body params go
+
+					// supporting file upload type
+					// if we used this in schema.type the JSON schema would be invalid
+					var schemaType = schema.type;
+
+					if (!schemaType && SupportedHacks.indexOf(schema.description) !== - 1){
+						schemaType = schema.description;
+					}
 
 					if (!route.settings.payload || !route.settings.payload.allow || route.settings.payload.allow.indexOf('application/json') >= 0) {
 						param = {


### PR DESCRIPTION
It is fairly common for POST endpoints to be able to receive a file as the body parameter. Since JSON schema does not support the `'file'` type, it is not possible to specify it when defining the schema.

This PR implements a hack that allows people to specify the `'file'` type through the description field.

I don't think it is nice, but I can't think of any other way to support this.
