### PR TITLE
Handles case when error path does not exist

### DIFF
--- a/lib/RequestValidator.js
+++ b/lib/RequestValidator.js
@@ -24,7 +24,7 @@ var RequestValidator = function(plugin, options) {
 			var report, errorMessages,
 				extractErrorMessage = function(error) {
 					var message = (error.description) ? error.message + '. Description: ' + error.description : error.message;
-					if (error.path){
+					if (error.path && error.path !== '#/'){
 						message += ' - on ';
 						// handles array case with second replacement
 						message += error.path.substr(2).replace(/\//g, '.').replace(/\.\[/g, '[');	


### PR DESCRIPTION
Turns out missing paths are possible :) if coming from ratify:
https://github.com/mac-/ratify/blob/master/lib/RouteSchemaManager.js#L230

If this is not handled a 500 occurs instead of 400
