### PR TITLE
Added support to report inner errors

### DIFF
--- a/lib/RequestValidator.js
+++ b/lib/RequestValidator.js
@@ -22,12 +22,19 @@ var RequestValidator = function(plugin, options) {
 
 		onPreHandler = function(request, next) {
 			var report, errorMessages,
-				extractErrorMessage = function(error) {
+				extractErrorMessage = function extractErrorMessage(error) {
 					var message = (error.description) ? error.message + '. Description: ' + error.description : error.message;
 					if (error.path && error.path !== '#/'){
 						message += ' - on ';
 						// handles array case with second replacement
 						message += error.path.substr(2).replace(/\//g, '.').replace(/\.\[/g, '[');	
+					}
+
+					if (error.inner && error.inner.length !== 0){
+						message += ': ';
+						message += error.inner.map(function(inner){
+							return extractErrorMessage(inner);
+						}).join('; ');
 					}
 
 					return message;


### PR DESCRIPTION
This PR adds support to report inner errors.

Nevertheless, I'm also thinking that the extract error message function should be a fallback to an optionally user defined function when configuring the plug-in.

Basically it would be used:

``` javascript
function customErrorMessageExtractor(error, defaultMessageExtractor){
  if (canExtractError(error)) { /* do so and return */ }
  return defaultMessageExtractor(error);
}
```

And also if no custom extractor is defined the default one would be used.

Thoughts?
