### PR TITLE
Basic hooks to customize swagger generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ A collection of valid response types returned by your services.
 
 Defaults to `['application/json']`
 
+### `swaggerHooks`
+
+An object in which the properties represent swagger generated elements and the values must be functions to be invoked to customize how those elements are processed.
+
+Possible values:
+* `params`: `function(params, route, type)`
+* `operation`: `function(operation, route, resourceType, path)`
 
 ### Parameter Validation
 

--- a/lib/SwaggerManager.js
+++ b/lib/SwaggerManager.js
@@ -5,6 +5,8 @@ var SwaggerManager = function(options) {
 
 	options = options || {};
 
+	var swaggerHooks = options.swaggerHooks || {};
+
 	var getRoutesGroupedByName = function(routes) {
 			var filteredRoutes = _.filter(routes, function(route) {
 				if (route.settings.plugins && route.settings.plugins[options.pluginName]) {
@@ -108,6 +110,10 @@ var SwaggerManager = function(options) {
 				}
 			}
 
+			if (swaggerHooks.params){
+				swaggerHooks.params(params, route, type);
+			}
+
 			return params;
 		},
 
@@ -127,7 +133,7 @@ var SwaggerManager = function(options) {
 					parameters: []
 				},
 				schema;
-			
+
 			if (route.settings.plugins &&
 				route.settings.plugins[options.pluginName] &&
 				(route.settings.plugins[options.pluginName]['payload'] ||
@@ -154,8 +160,12 @@ var SwaggerManager = function(options) {
 			operation.parameters = operation.parameters.concat(getSwaggerParams(route, 'payload'));
 
 			operation.parameters = operation.parameters.concat(getSwaggerParams(route, 'headers'));
-			
+
 			//TODO: warn if more than 1 param with the same name
+
+			if (swaggerHooks.operation){
+				swaggerHooks.operation(operation, route, resourceType, path);
+			}
 
 			return operation;
 		},


### PR DESCRIPTION
Useful hooks to customize how some swagger elements are generated. They are optional and do not prevent default behavior if provided.
