### PR TITLE
Allow no content header if payload is empty

### DIFF
--- a/lib/RouteSchemaManager.js
+++ b/lib/RouteSchemaManager.js
@@ -228,12 +228,17 @@ var RouteSchemaManager = function(options) {
 		if (!schemas || !schemas[validationTypes.PAYLOAD]) {
 			return { valid: true };
 		}
-		if (!request.raw.req.headers['content-type']) {
-			return { valid: false, errors: ['unable to validate payload: missing content-type header'] };
+
+		var headers = request.raw.req.headers;
+
+		if (!headers['content-type'] && request.payload &&
+					!(typeof request.payload === 'object' &&
+						Object.keys(request.payload).length === 0)){
+			return { valid: false, errors: ['unable to validate payload: missing content-type header and had content'] };
 		}
 
 		// convert payload types before validating only if payload is type application/x-www-form-urlencoded
-		if (request.raw.req.headers['content-type'].indexOf('application/x-www-form-urlencoded') === 0) {
+		if (headers['content-type'] && headers['content-type'].indexOf('application/x-www-form-urlencoded') === 0) {
 			convertPropertyTypesToMatchSchema(request.payload, schemas[validationTypes.PAYLOAD]);
 		}
 

--- a/test/RouteSchemaManager.tests.js
+++ b/test/RouteSchemaManager.tests.js
@@ -138,6 +138,24 @@ var assert = require('assert'),
 			}
 		}
 	},
+	mockRoute6 = {
+		method: 'POST',
+		path: '/good/fnord/allow/empty/body',
+		server: {
+			info: {
+				uri: 'http://fnord.com'
+			}
+		},
+		settings: {
+			plugins: {
+				ratify: {
+					payload: {
+						type: [ 'object', 'null' ]
+					}
+				}
+			}
+		}
+	},
 	mockRoutes = [mockRoute1, mockRoute2, mockRoute4];
 
 describe('RouteSchemaManager Unit Tests', function() {
@@ -509,7 +527,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 			assert(report.errors, 'errors obj should be valid');
 		});
 
-		it('should fail validation of payload when no content-type header present', function() {
+		it('should fail validation of payload when no content-type header present if there is content', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
@@ -527,6 +545,22 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(!report.valid, 'payload obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
+		});
+
+		it('should pass validation of payload when no content-type header present if there is no content', function() {
+
+			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
+				mockRequest = {
+					_route: mockRoute6,
+					raw: {
+						req: {
+							headers: {}
+						}
+					}
+				};
+			routeSchemaManager.initializeRoutes(mockRoute6.server.info.uri, mockRoutes);
+			var report = routeSchemaManager.validatePayload(mockRequest);
+			assert(report.valid, 'payload obj should be valid');
 		});
 	});
 


### PR DESCRIPTION
This provides support for schemas that have type `type: [ 'object', 'null' ]`. Basically, optional payloads.
