### PR TITLE
Fix ratify.js to use boom instead of hapi.error

### DIFF
--- a/lib/ratify.js
+++ b/lib/ratify.js
@@ -3,6 +3,7 @@
 var RequestValidator = require('./RequestValidator.js'),
 	SwaggerManager = require('./SwaggerManager.js'),
 	Hoek = require('hoek'),
+	Boom = require('boom'),
 	defaults = {
 		pluginName: 'ratify',
 		auth: false,
@@ -16,8 +17,7 @@ var RequestValidator = require('./RequestValidator.js'),
 
 module.exports.register = function (plugin, options, next) {
 
-	var Hapi = plugin.hapi,
-		settings = Hoek.applyToDefaults(defaults, options || {}),
+	var settings = Hoek.applyToDefaults(defaults, options || {}),
 		swaggerManager = new SwaggerManager(settings);
 
 	plugin.route({
@@ -42,7 +42,7 @@ module.exports.register = function (plugin, options, next) {
 					reply(swaggerManager.getApiDeclarationModel(routes, request.params.path));
 				}
 				else {
-					reply(Hapi.error.notFound());
+					reply(Boom.notFound());
 				}
 			}
 		}


### PR DESCRIPTION
As explained here: https://github.com/hapijs/hapi/issues/2186 `Hapi.error` is no longer available. That results in an unhanded error currently.