### PR TITLE
More Array Support - Convert properties for schema with multipart forms and handle arrays in query strings

### DIFF
--- a/lib/RouteSchemaManager.js
+++ b/lib/RouteSchemaManager.js
@@ -237,8 +237,8 @@ var RouteSchemaManager = function(options) {
 			return { valid: false, errors: ['unable to validate payload: missing content-type header and had content'] };
 		}
 
-		// convert payload types before validating only if payload is type application/x-www-form-urlencoded
-		if (headers['content-type'] && headers['content-type'].indexOf('application/x-www-form-urlencoded') === 0) {
+		// convert payload types before validating only if payload is type application/x-www-form-urlencoded or multipart/form-data
+		if (headers['content-type'] && (headers['content-type'].indexOf('application/x-www-form-urlencoded') === 0 || headers['content-type'].indexOf('multipart/form-data') === 0)) {
 			convertPropertyTypesToMatchSchema(request.payload, schemas[validationTypes.PAYLOAD]);
 		}
 

--- a/lib/SwaggerManager.js
+++ b/lib/SwaggerManager.js
@@ -112,6 +112,9 @@ var SwaggerManager = function(options) {
 							if (schema.properties[prop].hasOwnProperty('enum')) {
 								param.enum = schema.properties[prop].enum;
 							}
+							if (schema.properties[prop].hasOwnProperty('items')) {
+								param.items = schema.properties[prop].items;
+							}
 							params.push(param);
 						}
 					}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"dependencies": {
 		"hoek": "2.x.x",
 		"z-schema": "^3.0.1",

--- a/test/RouteSchemaManager.tests.js
+++ b/test/RouteSchemaManager.tests.js
@@ -15,10 +15,15 @@ var assert = require('assert'),
 	booleanSchema = {
 		type: 'boolean'
 	},
+	numberArraySchema = {
+		type: 'array',
+		items: numberSchema
+	},
 	objSchema = {
 		type: 'object',
 		properties: {
-			string: stringSchema
+			string: stringSchema,
+			numberArray: numberArraySchema
 		}
 	},
 	arraySchema = {
@@ -463,7 +468,29 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'file payload should be valid');
 		});
-
+		
+		it('should validate payload for route successfully for a file upload with array data', function() {
+			var fs = require('fs');
+			var data = fs.readFileSync('./test/jshint/config.json');
+			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
+				mockRequest = {
+					_route: mockRoute1,
+					payload: {
+						numberArray: ['5', '6']
+					},
+					raw: {
+						req: {
+							headers: {
+								'content-type': 'multipart/form-data'
+							}
+						}
+					}
+				};
+			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, [mockRoute1]);
+			var report = routeSchemaManager.validatePayload(mockRequest);
+			assert(report.valid, 'file payload should be valid');
+		});
+		
 		it('should validate payload for route with no payload schema successfully', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),


### PR DESCRIPTION
When submitting a form with fields and files, you have to use multipart/form-data instead of application/x-www-form-urlencoded.  If the schema had something that required a conversion (like an array of integers), it was always being rejected by ratify.