### PR TITLE
Fixes RequestValidator to read plugins from settings property

### DIFF
--- a/lib/RequestValidator.js
+++ b/lib/RequestValidator.js
@@ -59,17 +59,17 @@ var RequestValidator = function(plugin, options) {
 			var report, errorMessages;
 
 			// if route config contains a schema for the respose, and sample rate is greater than 0, validate it
-			if (request.route.plugins &&
-				request.route.plugins[options.pluginName] &&
-				request.route.plugins[options.pluginName].response &&
-				request.route.plugins[options.pluginName].response.schema &&
-				request.route.plugins[options.pluginName].response.sample !== 0 &&
-				request.route.plugins[options.pluginName].response.sample !== false) {
+			if (request.route.settings.plugins &&
+				request.route.settings.plugins[options.pluginName] &&
+				request.route.settings.plugins[options.pluginName].response &&
+				request.route.settings.plugins[options.pluginName].response.schema &&
+				request.route.settings.plugins[options.pluginName].response.sample !== 0 &&
+				request.route.settings.plugins[options.pluginName].response.sample !== false) {
 
 				// if sampling is enabled and the random sample value is greater than the defined sample rate, don't validate
-				if (request.route.plugins[options.pluginName].response.sample) {
+				if (request.route.settings.plugins[options.pluginName].response.sample) {
 					var currentSample = Math.ceil((Math.random() * 100));
-					if (currentSample > request.route.plugins[options.pluginName].response.sample) {
+					if (currentSample > request.route.settings.plugins[options.pluginName].response.sample) {
 						return reply.continue();
 					}
 				}
@@ -82,7 +82,7 @@ var RequestValidator = function(plugin, options) {
 				if (!report.valid) {
 					errorMessages = configuredErrorReporters['response'].extractMessage({ report: report, context: { request: request } });
 
-					if (request.route.plugins[options.pluginName].response.failAction === 'log') {
+					if (request.route.settings.plugins[options.pluginName].response.failAction === 'log') {
 						request.log(['validation', 'error'], errorMessages);
 						return reply.continue();
 					}


### PR DESCRIPTION
The RequestValidator was ignoring the `plugins` property and skipped the validation when `sample` was `true`.