### PR TITLE
JSON schema oneOf support for swagger

### DIFF
--- a/lib/SwaggerManager.js
+++ b/lib/SwaggerManager.js
@@ -153,6 +153,12 @@ var SwaggerManager = function(options) {
 				if (plugins[options.pluginName].response.schema){
 					schema = plugins[options.pluginName].response.schema;
 
+					if (schema.oneOf &&
+						Array.isArray(schema.oneOf) &&
+						schema.oneOf.length > 0) {
+						schema = schema.oneOf[0];
+					}
+
 					if (schema.type === 'object') {
 						operation.type = operation.nickname + '_response';
 					}
@@ -211,6 +217,10 @@ var SwaggerManager = function(options) {
 				plugins[options.pluginName][modelKind] && modelGetter()) {
 				model = _.cloneDeep(modelGetter());
 
+				if(model.oneOf && Array.isArray(model.oneOf) && model.oneOf.length > 0) {
+					model = model.oneOf[0];
+				}
+
 				if (model.type === 'array') {
 					model = _.cloneDeep(model.items);
 				}
@@ -243,13 +253,21 @@ var SwaggerManager = function(options) {
 
 			Object.keys(model.properties).forEach(function(prop){
 				if (model.properties[prop].properties ||
+					model.properties[prop].oneOf ||
 				 	model.properties[prop].type === 'object' ||
 				 	(Array.isArray(model.properties[prop].type) &&
 				 	model.properties[prop].type.indexOf('object') >= 0)){
+
+					if (model.properties[prop].oneOf &&
+						Array.isArray(model.properties[prop].oneOf) &&
+						model.properties[prop].oneOf.length > 0) {
+						// Replace the node with the first occurrence of the Array and go through this model again.
+						model.properties[prop] = model.properties[prop].oneOf[0];
+						return generateNestedModels(model, models, prefix, parent);
+					}
+
 					models[prefix + prop] = _.cloneDeep(model.properties[prop]);
-
 					generateNestedModels(model.properties[prop], models, prefix, parent + prop + '.');
-
 					model.properties[prop] = { $ref: prefix + prop};
 				}
 			});


### PR DESCRIPTION
# Brief

Adds support to detect the `oneOf` property and replace the value with the first defined schema in the array. This prevents swagger from breaking as they don't support `oneOf`.

E.g.:

````
response: {
    schema: {
         oneOf: [
              { type: 'object', properties: { ... } },
              { type: 'array', items: { ... } }
         ]
   }
}
````

Will replace the node `oneOf` with the first defined schema, i.e. with `{ type: 'object', properties: { ... } }`. This way Swagger continues to work showing the documentation for the first schema in the array.

**Note:** It does not support `definitions`. It'll only work for inline schemas as the example above.