### PR TITLE
added ability to override `operation.nickname` from plugin settings

### DIFF
--- a/lib/SwaggerManager.js
+++ b/lib/SwaggerManager.js
@@ -141,7 +141,7 @@ var SwaggerManager = function(options) {
 					notes: route.settings.notes,
 					tags: route.settings.tags,
 					type: 'void',
-					nickname: route.method + '_' + nickname,
+					nickname: route.settings.plugins[options.pluginName].nickname || (route.method + '_' + nickname),
 					parameters: []
 				},
 				schema,


### PR DESCRIPTION
I have the following endpoints:
* `DELETE /api/users` (delete all users)
* `DELETE /api/connections/{id}/users` (delete all connection users)

And both endpoints are generating the same `operation.nickname` -> `delete_users`